### PR TITLE
Fix mis-spelling

### DIFF
--- a/contracts/Poole.sol
+++ b/contracts/Poole.sol
@@ -9,7 +9,7 @@ import "./James.sol";
 import "./oz/SafeMath.sol";
 import "./oz/IERC20.sol";
 
-contract JamesPool {
+contract JamesPoole {
     using SafeMath for uint256;
 
     event Sync (


### PR DESCRIPTION
It looks like the original contract had some typos.  I have fixed it here, but of course I didn't test or do anything to see if it still works.  Please accept.